### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,9 +11,9 @@
 
     <title>{{ .Title }} -- {{ .Site.Title }}</title>
 
-    {{ if .RSSlink }}
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-    <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+    {{ if .RSSLink }}
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{ end }}
 
     <!-- Bootstrap Core CSS -->


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.