### PR TITLE
Fix for description case sensitivity

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,7 +8,7 @@
            <div class="site-heading">
              <h1>{{ .Site.Title }}</h1>
              <hr class="small">
-             {{ if isset .Site.Params "Description" }}<span class="subheading">{{ .Site.Params.Description }}</span>{{ end }}
+             {{ with .Site.Params.Description }}<span class="subheading">{{ . }}</span>{{ end }}
            </div>
          </div>
        </div>


### PR DESCRIPTION
@humboldtux, Thanks for the advice earlier.

This fixes an issue where description may not be displayed, due to a case sensitivity bug. Using 'with' fixes this. The fix also makes the param none sensitive to capitalisation in the config file.