### PR TITLE
Change min_version from 0.18.1 to 0.18

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "Startbootstrap Clean Blog"
 homepage = "https://github.com/humboldtux/startbootstrap-clean-blog"
 tags = ["blog", "bootstrap"]
 features = ["blog", "bootstrap"]
-min_version = 0.18.1
+min_version = 0.18
 
 [author]
   name = "Benoît Benedetti"


### PR DESCRIPTION
hugo currently treats min_version as a float number, and thus,
for better or for worse, we cannot use have a version number with
more than one dot, otherwise the following error would occur when
trying to generate https://themes.gohugo.io/ :

ERROR: page.go:1309: Error parsing page meta data for startbootstrap-clean-blog.md
ERROR: page.go:1310: (15, 15): cannot have two dots in one float
ERROR: page.go:683: (15, 15): cannot have two dots in one float

Thank you!