### PR TITLE
Populate description, author and keywords meta tags

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,8 +6,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="">
-    <meta name="author" content="">
+    <meta name="description" content="{{ if .Description }}{{ .Description }}{{ end }}">
+    <meta name="author" content="{{ if .Params.authors }}{{ .Params.authors }}{{ else if .Site.Params.Author }}{{.Site.Params.Author}}{{ end }}">
+    <meta name="keywords" content="{{ if .Keywords }}{{ delimit .Keywords ", " }}{{ end }}">
+
 
     <title>{{ .Title }} -- {{ .Site.Title }}</title>
 


### PR DESCRIPTION
I'm using the items in this PR to populate the Author, Description and Keywords meta tags if they are defined. Thought this might be beneficial to everyone else who uses your awesome theme!

- Ryan